### PR TITLE
Fix Quiz Card positioning and font size (#14, #15)

### DIFF
--- a/src/app/joy-quiz/page.tsx
+++ b/src/app/joy-quiz/page.tsx
@@ -219,7 +219,7 @@ export default function QuizPage() {
   const isFlaggedCurrent = flagged.has(currentIndex);
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen">
+    <div className="flex flex-col items-center justify-start min-h-screen pt-8">
       <div className="w-240">
         <ProgressBar current={currentIndex} total={questions.length} />
 

--- a/src/components/QuizCard.tsx
+++ b/src/components/QuizCard.tsx
@@ -66,7 +66,7 @@ export function QuizCard({
             type="button"
             onClick={() => handleOptionClick(option.label)}
             disabled={disabled || feedback !== null}
-            className={`w-full rounded-lg border-2 px-4 py-3 text-left font-medium transition-all ${
+            className={`w-full rounded-lg border-2 px-4 py-3 text-left font-medium text-lg transition-all ${
               selectedOption === option.label
                 ? feedback === 'correct'
                   ? 'border-green-500 bg-green-50 text-green-900 dark:bg-green-900 dark:text-green-100'


### PR DESCRIPTION
## Summary
This PR fixes two related issues with the Quiz Card component:

**Issue #14**: The layout of Joy Quiz to be positioned at the top appropriately
- Changed justify-center to justify-start on the main container
- Added pt-8 (padding-top) to provide proper spacing from the header
- The Quiz Card is now positioned at the top of the page instead of centered

**Issue #15**: The bigger font size for a choice in Quiz Card
- Increased quiz option button font size to text-lg for better readability
- Improves visibility and user experience when selecting quiz options

## Changes
- Modified \src/app/joy-quiz/page.tsx\: Updated flex container alignment
- Modified \src/components/QuizCard.tsx\: Added text-lg class to option buttons

## Testing
- Verified Quiz Card appears at the top of the page on load
- Confirmed quiz options have larger, more readable text