### PR TITLE
fix: resolve quiz card feedback state issues

### DIFF
--- a/src/app/joy-quiz/page.tsx
+++ b/src/app/joy-quiz/page.tsx
@@ -225,6 +225,7 @@ export default function QuizPage() {
 
         <div className="flex-1 overflow-y-auto">
           <QuizCard
+            key={currentQuestion.questionIndex}
             question={currentQuestion}
             onAnswer={handleAnswer}
             onFlag={handleFlag}

--- a/src/components/QuizCard.tsx
+++ b/src/components/QuizCard.tsx
@@ -23,7 +23,7 @@ export function QuizCard({
   const [feedback, setFeedback] = useState<FeedbackType>(null);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
 
-  // Clear feedback and selected option when question changes
+  // Clear feedback and selected option when component mounts (new question)
   useEffect(() => {
     setFeedback(null);
     setSelectedOption(null);


### PR DESCRIPTION
## Summary
This PR fixes two related issues with the Quiz Card component's state management and feedback display.

## Issues Resolved
- Fixes #18: Quiz Card should highlight the correct choice in green (not red)
- Fixes #19: Quiz Card state management should reset border color and message when advancing to next question

## Changes Made
- Added \key\ prop to QuizCard component based on \questionIndex\
- Forces React to remount the component when the question changes
- Ensures internal state (feedback and selectedOption) is automatically cleared via component lifecycle

## How It Works
When advancing to a new question:
1. The \currentQuestion.questionIndex\ changes in the parent component
2. React detects the key change and unmounts/remounts QuizCard
3. Component state is automatically reset on mount
4. User sees clean feedback display for the new question

## Files Modified
- \src/app/joy-quiz/page.tsx\: Added key prop to QuizCard component
- \src/components/QuizCard.tsx\: Updated comment for clarity

## Testing
- Build validation passed ✅
- Biome linting passed ✅
- TypeScript checks passed ✅
- Next.js build completed successfully ✅