### PR TITLE
fix: show all correct choices with green border in quiz card

### DIFF
--- a/src/components/QuizCard.tsx
+++ b/src/components/QuizCard.tsx
@@ -67,11 +67,15 @@ export function QuizCard({
             onClick={() => handleOptionClick(option.label)}
             disabled={disabled || feedback !== null}
             className={`w-full rounded-lg border-2 px-4 py-3 text-left font-medium text-lg transition-all ${
-              selectedOption === option.label
+              feedback
                 ? option.label === question.correctAnswer
                   ? 'border-green-500 bg-green-50 text-green-900 dark:bg-green-900 dark:text-green-100'
-                  : 'border-red-500 bg-red-50 text-red-900 dark:bg-red-900 dark:text-red-100'
-                : 'border-gray-300 bg-white text-gray-900 hover:border-blue-400 dark:border-gray-600 dark:bg-gray-700 dark:text-white'
+                  : selectedOption === option.label
+                    ? 'border-red-500 bg-red-50 text-red-900 dark:bg-red-900 dark:text-red-100'
+                    : 'border-gray-300 bg-white text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white'
+                : selectedOption === option.label
+                  ? 'border-blue-400 bg-blue-50 text-blue-900 dark:bg-blue-900 dark:text-blue-100'
+                  : 'border-gray-300 bg-white text-gray-900 hover:border-blue-400 dark:border-gray-600 dark:bg-gray-700 dark:text-white'
             } ${
               disabled || feedback !== null ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'
             }`}


### PR DESCRIPTION
## Description
Fixes the quiz card highlighting behavior to properly display the correct answer in green after submission.

## Changes
- Modified QuizCard component to show all correct choices with green border
- Selected incorrect answer displays with red border
- Other options remain with default gray border
- Logic now distinguishes between pre-feedback and post-feedback states

## Testing
- When a user selects an answer, feedback is displayed
- The correct choice is highlighted in green (regardless of user selection)
- If user selected incorrectly, that choice shows red
- Passes all pre-commit checks and TypeScript validation

## Fixes
Fixes #18