### PR TITLE
fix: set turbopack.root to silence workspace root warning (Fixes #46)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  turbopack: {
+    root: __dirname,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Fixes #46

## Problem
When running `next dev`, a warning appears: 'Warning: Next.js inferred your workspace root, but it may not be correct.' This occurs because Next.js detects multiple lockfiles in the directory structure (package-lock.json in parent directory and pnpm-lock.yaml in the project).

## Solution
Set `turbopack.root` explicitly in next.config.ts to the project root directory (__dirname). This silences the warning by ensuring Next.js/Turbopack uses the correct root, even when multiple lockfiles are detected.

## Changes
- Updated `next.config.ts` to include `turbopack.root` configuration

## Testing
- Build passes successfully: `pnpm build`
- No workspace root warning appears when running `next dev`